### PR TITLE
fix(config): add options to the rule `@typescript-eslint/no-unused-vars`

### DIFF
--- a/src/typescript/index.js
+++ b/src/typescript/index.js
@@ -109,6 +109,12 @@ module.exports = {
 		"@typescript-eslint/no-unnecessary-type-arguments": "error",
 		"@typescript-eslint/no-unnecessary-type-assertion": "error",
 		"@typescript-eslint/no-unused-expressions": "error",
+		"@typescript-eslint/no-unused-vars": [
+			"error",
+			{
+				argsIgnorePattern: "^_"
+			}
+		],
 		"@typescript-eslint/no-var-requires": "off",
 		"@typescript-eslint/prefer-for-of": "error",
 		"@typescript-eslint/prefer-as-const": "off",


### PR DESCRIPTION
Add `argsIgnorePattern` option to the rule `@typescript-eslint/no-unused-vars` to ignore unsused
functions arguments start with `_`.

ISSUES CLOSED: #70