### PR TITLE
fix(config): remove `env` options

### DIFF
--- a/src/typescript/index.js
+++ b/src/typescript/index.js
@@ -1,8 +1,4 @@
 module.exports = {
-	env: {
-		browser: true,
-		es2020: true
-	},
 	parser: "@typescript-eslint/parser",
 	parserOptions: {
 		project: "tsconfig.json",


### PR DESCRIPTION
The `env` options are not necessary and force to use a specific version of ecmasctipt. This could cause issue when linting